### PR TITLE
Fix issue ref error with React V16

### DIFF
--- a/nwb.config.js
+++ b/nwb.config.js
@@ -5,8 +5,10 @@ module.exports = {
     umd: {
       global: 'materialui-pagination',
       externals: {
-        react: 'React'
+        // Don't bundle react or react-dom
+        'react': 'React',
+        'react-dom': 'ReactDOM',
       }
     }
   }
-}
+};

--- a/package.json
+++ b/package.json
@@ -21,8 +21,6 @@
   "dependencies": {
     "material-ui": "^0.17.0",
     "prop-types": "^15.5.8",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2",
     "react-tap-event-plugin": "^2.0.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,12 +26,13 @@
     "react-tap-event-plugin": "^2.0.1"
   },
   "peerDependencies": {
-    "react": "15.x"
+    "react": "^15.3.0 || ^16.0.0",
+    "react-dom": "^15.3.0 || ^16.0.0"
   },
   "devDependencies": {
     "nwb": "0.15.x",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4"
+    "react": "^15.3.0 || ^16.0.0",
+    "react-dom": "^15.3.0 || ^16.0.0"
   },
   "author": "",
   "homepage": "https://github.com/franciskim722/materialui-pagination#readme",


### PR DESCRIPTION
It fix the issue [7](https://github.com/franciskim722/materialui-pagination/issues/7) by adding react-dom as an external libs and also updates the devDependencies to include react 16.